### PR TITLE
Fix null per_run_cost values for postgres MCP servers

### DIFF
--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -153,7 +153,7 @@
         "avg_turns": 25.9643,
         "per_run_input_tokens": 10137105.75,
         "per_run_output_tokens": 214451.25,
-        "per_run_cost": null,
+        "per_run_cost": 63.54778763,
         "actual_model_name": "claude-sonnet-4-5-20250929",
         "pass@1": {
           "avg": 0.4881,
@@ -186,7 +186,7 @@
         "avg_turns": 19.8571,
         "per_run_input_tokens": 8063636.25,
         "per_run_output_tokens": 147768,
-        "per_run_cost": null,
+        "per_run_cost": 49.9983375,
         "actual_model_name": "claude-sonnet-4-5-20250929",
         "pass@1": {
           "avg": 0.5476,
@@ -219,7 +219,7 @@
         "avg_turns": 21.3929,
         "per_run_input_tokens": 11408983.25,
         "per_run_output_tokens": 233985.25,
-        "per_run_cost": null,
+        "per_run_cost": 71.61856763,
         "actual_model_name": "claude-sonnet-4-5-20250929",
         "pass@1": {
           "avg": 0.5238,


### PR DESCRIPTION
## Summary
- Fixed null `per_run_cost` values for CrystalDBA, InsForge, and Supabase postgres entries in `mcp_servers.json`
- Calculated costs using Claude Sonnet 4.5 tiered pricing model

## Pricing Model Applied
**Input tokens:**
- First 200K tokens: $3/MTok
- Tokens > 200K: $6/MTok

**Output tokens:**
- First 200K tokens: $15/MTok  
- Tokens > 200K: $22.50/MTok

## Results
- **CrystalDBA**: `$63.54778763` per run
- **InsForge**: `$49.9983375` per run
- **Supabase**: `$71.61856763` per run

## Test plan
- [x] Verified tiered pricing calculation for all three postgres entries
- [x] Confirmed values replace null fields correctly
- [x] JSON structure remains valid

<img width="295" height="811" alt="Screenshot 2025-11-05 at 20 19 57" src="https://github.com/user-attachments/assets/4b371e4d-065b-4d00-8390-91e5bfbf6369" />

This is the pricing of sonnet 4.5

Postgres
 - per_run_input_tokens: 10,137,105.75
  - per_run_output_tokens: 214,451.25


(200,000 × 3 + 9,937,105.75 * 6  + 200000*15 + 14,451.25*22.5) / 1M = 63.547

InsForge

  - per_run_input_tokens: 8,063,636.25
  - per_run_output_tokens: 147,768

  (200,000 × 3 + 7,863,636.25 × 6 + 147,768 × 15) / 1M = 49.998

  ---
  Supabase

  - per_run_input_tokens: 11,408,983.25
  - per_run_output_tokens: 233,985.25

  (200,000 × 3 + 11,208,983.25 × 6 + 200,000 × 15 + 33,985.25 × 22.5) / 1M = 71.619
